### PR TITLE
Use Java 18

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,7 @@ plugins {
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
-    vendor = JvmVendorSpec.ADOPTOPENJDK
+    languageVersion = JavaLanguageVersion.of(18)
   }
 }
 


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit
* **Merge strategy:** Merge (no squash)

## Description
This PR bumps the Lander model to use Java 18, matching the version bump performed in NASA-AMMOS/aerie#129.

## Verification
I was able to compile and run it successfully, and use the produced JAR to execute the `AerieRulesLanderTest` in the main repository.