### PR TITLE
Allow only true/false strings for `useLocalAerie`

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -2,7 +2,11 @@ import java.nio.file.Path
 
 rootProject.name = 'aerielander'
 
-if (useLocalAerie == "true") {
+if (!['true', 'false'].any { useLocalAerie.equalsIgnoreCase(it) }) {
+    throw new GradleException("Property 'useLocalAerie' must be either 'true' or 'false' (case-insensitive). Found: '$useLocalAerie'")
+}
+
+if (useLocalAerie.equalsIgnoreCase('true')) {
   def fullAeriePath = Path.of(rootProject.projectDir.absolutePath.toString(), localAeriePath)
     
   include ':contrib',


### PR DESCRIPTION
* **Tickets addressed:** None
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description

Previously `useLocalAerie` would only work if an exact value of `true` was passed along.
This is fairly brittle, so now `-PuseLocalAerie=<anything but whitespace or "false" ([a-zA-Z])` will be interpreted as `true`.

