### PR TITLE
[REFACTOR] Update mission model constructor to take planStart

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,14 +31,14 @@ dependencies {
     testImplementation project(':merlin-framework-junit')
   }
   else {
-    compileOnly 'gov.nasa.jpl.aerie:contrib:0.11.0-SNAPSHOT-+'
-    compileOnly 'gov.nasa.jpl.aerie:merlin-framework:0.11.0-SNAPSHOT-+'
-    implementation 'gov.nasa.jpl.aerie:parsing-utilities:0.11.0-SNAPSHOT-+'
-    annotationProcessor 'gov.nasa.jpl.aerie:merlin-framework-processor:0.11.0-SNAPSHOT-+'
+    compileOnly 'gov.nasa.jpl.aerie:contrib:0.13.0-SNAPSHOT-+'
+    compileOnly 'gov.nasa.jpl.aerie:merlin-framework:0.13.0-SNAPSHOT-+'
+    implementation 'gov.nasa.jpl.aerie:parsing-utilities:0.13.0-SNAPSHOT-+'
+    annotationProcessor 'gov.nasa.jpl.aerie:merlin-framework-processor:0.13.0-SNAPSHOT-+'
 
-    testImplementation 'gov.nasa.jpl.aerie:contrib:0.11.0-SNAPSHOT-+'
-    testImplementation 'gov.nasa.jpl.aerie:merlin-driver:0.11.0-SNAPSHOT-+'
-    testImplementation 'gov.nasa.jpl.aerie:merlin-framework-junit:0.11.0-SNAPSHOT-+'
+    testImplementation 'gov.nasa.jpl.aerie:contrib:0.13.0-SNAPSHOT-+'
+    testImplementation 'gov.nasa.jpl.aerie:merlin-driver:0.13.0-SNAPSHOT-+'
+    testImplementation 'gov.nasa.jpl.aerie:merlin-framework-junit:0.13.0-SNAPSHOT-+'
   }
 
   testImplementation 'org.assertj:assertj-core:3.22.0'

--- a/src/main/java/gov/nasa/jpl/aerielander/Mission.java
+++ b/src/main/java/gov/nasa/jpl/aerielander/Mission.java
@@ -14,6 +14,8 @@ import gov.nasa.jpl.aerielander.models.seis.SeisModel;
 import gov.nasa.jpl.aerielander.models.time.Clocks;
 import gov.nasa.jpl.aerielander.models.wake.WakeModel;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerielander.models.time.Time.Mars_Time_Origin;
 
 public final class Mission {
@@ -30,7 +32,7 @@ public final class Mission {
   public final APSSModel apssModel;
   public final SeisModel seisModel;
 
-  public Mission(final Registrar registrar, final Configuration config) {
+  public Mission(final Registrar registrar, final Instant planStart, final Configuration config) {
     this.config = config;
     this.clocks = new Clocks(Mars_Time_Origin);
     this.dataModel = new DataModel();

--- a/src/main/java/gov/nasa/jpl/aerielander/parsers/MerlinParsers.java
+++ b/src/main/java/gov/nasa/jpl/aerielander/parsers/MerlinParsers.java
@@ -1,8 +1,8 @@
 package gov.nasa.jpl.aerielander.parsers;
 
-import gov.nasa.jpl.aerie.json.Iso;
 import gov.nasa.jpl.aerie.json.JsonParseResult;
 import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.json.SchemaCache;
 
 import javax.json.Json;
 import javax.json.JsonObject;
@@ -24,7 +24,7 @@ public abstract class MerlinParsers {
     private MerlinParsers() {}
     public static final JsonParser<Timestamp> timestampP = new JsonParser<>() {
         @Override
-        public JsonObject getSchema(final Map<Object, String> anchors) {
+        public JsonObject getSchema(final SchemaCache anchors) {
             return Json
                     .createObjectBuilder(stringP.getSchema())
                     .add("format", "date-time")
@@ -59,10 +59,9 @@ public abstract class MerlinParsers {
             . field("type", stringP)
             . field("startTimestamp", timestampP)
             . field("parameters", mapP(serializedValueP))
-            . map(Iso.of(
-                    untuple((type, startTimestamp, parameters) ->
-                            new ActivityInstance(type, startTimestamp, parameters)),
-                    activity -> tuple(activity.type, activity.startTimestamp, activity.parameters)));
+            . map(untuple((type, startTimestamp, parameters) ->
+                      new ActivityInstance(type, startTimestamp, parameters)),
+                  activity -> tuple(activity.type, activity.startTimestamp, activity.parameters));
 
     public static final JsonParser<NewPlan> newPlanP
             = productP
@@ -72,9 +71,8 @@ public abstract class MerlinParsers {
             . field("endTimestamp", timestampP)
             . optionalField("activityInstances", listP(activityInstanceP))
             . optionalField("configuration", mapP(serializedValueP))
-            . map(Iso.of(
-                    untuple((name, adaptationId, startTimestamp, endTimestamp, activityInstances, configuration) ->
-                            new NewPlan(name, adaptationId, startTimestamp, endTimestamp, activityInstances.orElse(List.of()), configuration.orElse(Map.of()))),
-                    $ -> tuple($.name, $.adaptationId, $.startTimestamp, $.endTimestamp, Optional.of($.activityInstances), Optional.of($.configuration))));
+            . map(untuple((name, adaptationId, startTimestamp, endTimestamp, activityInstances, configuration) ->
+                      new NewPlan(name, adaptationId, startTimestamp, endTimestamp, activityInstances.orElse(List.of()), configuration.orElse(Map.of()))),
+                  $ -> tuple($.name, $.adaptationId, $.startTimestamp, $.endTimestamp, Optional.of($.activityInstances), Optional.of($.configuration)));
 
 }

--- a/src/main/java/gov/nasa/jpl/aerielander/parsers/SerializedValueJsonParser.java
+++ b/src/main/java/gov/nasa/jpl/aerielander/parsers/SerializedValueJsonParser.java
@@ -2,6 +2,7 @@ package gov.nasa.jpl.aerielander.parsers;
 
 import gov.nasa.jpl.aerie.json.JsonParseResult;
 import gov.nasa.jpl.aerie.json.JsonParser;
+import gov.nasa.jpl.aerie.json.SchemaCache;
 import gov.nasa.jpl.aerie.merlin.protocol.types.SerializedValue;
 
 import javax.json.Json;
@@ -19,7 +20,7 @@ public final class SerializedValueJsonParser implements JsonParser<SerializedVal
     public static final JsonParser<SerializedValue> serializedValueP = new SerializedValueJsonParser();
 
     @Override
-    public JsonObject getSchema(final Map<Object, String> anchors) {
+    public JsonObject getSchema(final SchemaCache anchors) {
         return Json.createObjectBuilder().add("type", "any").build();
     }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/DataModelTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/DataModelTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,7 +47,7 @@ public final class DataModelTest {
 
     public DefaultConfigurationTests(final MerlinTestContext<ActivityTypes, Mission> ctx) {
       final var config = Configuration.defaultConfiguration();
-      mission = new Mission(ctx.registrar(), config);
+      mission = new Mission(ctx.registrar(), Instant.EPOCH, config);
       ctx.use(mission, ActivityTypes::register);
       dataModel = mission.dataModel;
     }
@@ -192,7 +193,7 @@ public final class DataModelTest {
               OrbiterConfiguration.defaults
           )
       );
-      mission = new Mission(ctx.registrar(), config);
+      mission = new Mission(ctx.registrar(), Instant.EPOCH, config);
       ctx.use(mission, ActivityTypes::register);
       dataModel = mission.dataModel;
     }

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/apss/APSSChangeAcqConfigTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/apss/APSSChangeAcqConfigTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerielander.generated.ActivityActions.spawn;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -20,7 +22,7 @@ public class APSSChangeAcqConfigTest {
   private final Mission mission;
 
   public APSSChangeAcqConfigTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/apss/APSSContinuousConfigFileUpdateTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/apss/APSSContinuousConfigFileUpdateTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class APSSContinuousConfigFileUpdateTest {
 
@@ -18,7 +20,7 @@ public class APSSContinuousConfigFileUpdateTest {
   private final Mission mission;
 
   public APSSContinuousConfigFileUpdateTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/apss/APSSGenericTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/apss/APSSGenericTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MINUTES;
 import static gov.nasa.jpl.aerielander.generated.ActivityActions.spawn;
@@ -26,7 +28,7 @@ public class APSSGenericTest {
   private final Mission mission;
 
   public APSSGenericTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/apss/APSSPaeDataRecoveryTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/apss/APSSPaeDataRecoveryTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class APSSPaeDataRecoveryTest {
 
@@ -18,7 +20,7 @@ public class APSSPaeDataRecoveryTest {
   private final Mission mission;
 
   public APSSPaeDataRecoveryTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/apss/APSSProcessContinuousDataTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/apss/APSSProcessContinuousDataTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class APSSProcessContinuousDataTest {
 
@@ -18,7 +20,7 @@ public class APSSProcessContinuousDataTest {
   private final Mission mission;
 
   public APSSProcessContinuousDataTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/apss/APSSTwinsBoomSwapTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/apss/APSSTwinsBoomSwapTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MINUTES;
 import static gov.nasa.jpl.aerielander.generated.ActivityActions.spawn;
@@ -25,7 +27,7 @@ public class APSSTwinsBoomSwapTest {
   private final Mission mission;
 
   public APSSTwinsBoomSwapTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/eng/AddDataToVirtualChannelTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/eng/AddDataToVirtualChannelTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MINUTES;
 import static gov.nasa.jpl.aerielander.generated.ActivityActions.spawn;
@@ -25,7 +27,7 @@ public class AddDataToVirtualChannelTest {
   private final Mission mission;
 
   public AddDataToVirtualChannelTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/eng/ChangeDefaultDartTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/eng/ChangeDefaultDartTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 import static gov.nasa.jpl.aerielander.generated.ActivityActions.spawn;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +26,7 @@ public class ChangeDefaultDartTest {
   private final Mission mission;
 
   public ChangeDefaultDartTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/eng/ChangeDefaultFptTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/eng/ChangeDefaultFptTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 import static gov.nasa.jpl.aerielander.generated.ActivityActions.spawn;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +26,7 @@ public class ChangeDefaultFptTest {
   private final Mission mission;
 
   public ChangeDefaultFptTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/eng/EngGenericTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/eng/EngGenericTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
 import static gov.nasa.jpl.aerielander.generated.ActivityActions.spawn;
@@ -25,7 +27,7 @@ public class EngGenericTest {
   private final Mission mission;
 
   public EngGenericTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/eng/RetransmitTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/eng/RetransmitTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.SECONDS;
 import static gov.nasa.jpl.aerielander.generated.ActivityActions.spawn;
@@ -25,7 +27,7 @@ public class RetransmitTest {
   private final Mission mission;
 
   public RetransmitTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/eng/SafeModeTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/eng/SafeModeTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 import static gov.nasa.jpl.aerielander.generated.ActivityActions.spawn;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +26,7 @@ public class SafeModeTest {
   private final Mission mission;
 
   public SafeModeTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/eng/TetherStorageBoxHeatersTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/eng/TetherStorageBoxHeatersTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerielander.generated.ActivityActions.spawn;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -20,7 +22,7 @@ public class TetherStorageBoxHeatersTest {
   private final Mission mission;
 
   public TetherStorageBoxHeatersTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/activities/eng/UseAlternateUhfBlockTest.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/activities/eng/UseAlternateUhfBlockTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import java.time.Instant;
+
 import static gov.nasa.jpl.aerie.merlin.framework.ModelActions.delay;
 import static gov.nasa.jpl.aerie.merlin.protocol.types.Duration.MINUTES;
 import static gov.nasa.jpl.aerielander.generated.ActivityActions.spawn;
@@ -25,7 +27,7 @@ public class UseAlternateUhfBlockTest {
   private final Mission mission;
 
   public UseAlternateUhfBlockTest(final MerlinTestContext<ActivityTypes, Mission> ctx) {
-    this.mission = new Mission(ctx.registrar(), Configuration.defaultConfiguration());
+    this.mission = new Mission(ctx.registrar(), Instant.EPOCH, Configuration.defaultConfiguration());
     ctx.use(mission, ActivityTypes::register);
   }
 

--- a/src/test/java/gov/nasa/jpl/aerielander/simulations/SimulatePlan.java
+++ b/src/test/java/gov/nasa/jpl/aerielander/simulations/SimulatePlan.java
@@ -32,7 +32,7 @@ public final class SimulatePlan {
   private static MissionModel<RootModel<ActivityTypes, Mission>> makeMissionModel(final MissionModelBuilder builder, final Configuration config) {
     final var factory = new GeneratedMissionModelFactory();
     final var registry = DirectiveTypeRegistry.extract(factory);
-    final var model = factory.instantiate(registry.registry(), config, builder);
+    final var model = factory.instantiate(registry.registry(), Instant.EPOCH, config, builder);
     return builder.build(model, factory.getConfigurationType(), registry);
   }
 


### PR DESCRIPTION
* **Tickets addressed:** NA
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
Updated mission model constructor to take planStart parameter. Updated tests similarly.

## Verification
Build, run test, use mission model in an Aerie deployment simulation context

## Documentation
None invalidated or needed

## Future work
None
