### PR TITLE
Fix scheduler plugin package in META-INF/services

### DIFF
--- a/src/main/resources/META-INF/services/gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin
+++ b/src/main/resources/META-INF/services/gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin
@@ -1,1 +1,1 @@
-gov.nasa.jpl.aerie.aerielander.generated.GeneratedSchedulerPlugin
+gov.nasa.jpl.aerielander.generated.GeneratedSchedulerPlugin


### PR DESCRIPTION
* **Tickets addressed:** N/A
* **Review:** By commit  <!-- Choose from: "by commit", "by file" -->
* **Merge strategy:** Merge (no squash)  <!-- Choose from: "merge (no squash)", "squash and merge" -->

## Description
<!-- Imagine your reviewer asking you these questions and then answer them here: 
What approach was taken to satisfy the ticket being addressed?
What should reviewers be aware of? -->

Attempting to run scheduling on an aerie lander mission model jar results in the following exception:

```
gov.nasa.jpl.aerie.scheduler.server.exceptions.ResultsProtocolFailure: No implementation found for `SchedulerPlugin` at path `/usr/src/app/merlin_file_store/aerielander-1690300990747-GtIrAtqsWNCuoo.jar` wih name "Aerie Lander Sleep Exception" and version "1.0.0"
	at gov.nasa.jpl.aerie.scheduler.worker.services.SynchronousSchedulerAgent.loadMissionModel(SynchronousSchedulerAgent.java:451)
	at gov.nasa.jpl.aerie.scheduler.worker.services.SynchronousSchedulerAgent.schedule(SynchronousSchedulerAgent.java:119)
	at gov.nasa.jpl.aerie.scheduler.worker.SchedulerWorkerAppDriver.main(SchedulerWorkerAppDriver.java:90)
Caused by: gov.nasa.jpl.aerie.scheduler.worker.services.SynchronousSchedulerAgent$SchedulerModelLoadException: No implementation found for `SchedulerPlugin` at path `/usr/src/app/merlin_file_store/aerielander-1690300990747-GtIrAtqsWNCuoo.jar` wih name "Aerie Lander Sleep Exception" and version "1.0.0"
	at gov.nasa.jpl.aerie.scheduler.worker.services.SynchronousSchedulerAgent.loadSchedulerModelProvider(SynchronousSchedulerAgent.java:485)
	at gov.nasa.jpl.aerie.scheduler.worker.services.SynchronousSchedulerAgent.loadMissionModel(SynchronousSchedulerAgent.java:449)
	... 2 more
Caused by: java.lang.ClassNotFoundException: gov.nasa.jpl.aerie.aerielander.generated.GeneratedSchedulerPlugin
	at java.base/java.net.URLClassLoader.findClass(Unknown Source)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
	at java.base/java.lang.ClassLoader.loadClass(Unknown Source)
	at gov.nasa.jpl.aerie.scheduler.worker.services.SynchronousSchedulerAgent.loadSchedulerModelProvider(SynchronousSchedulerAgent.java:472)
	... 3 more
```

This is because the contents of `gov.nasa.jpl.aerie.merlin.protocol.model.SchedulerPlugin` are outdated, and include the package name that aerie lander had back when it was included in the `aerie` repo.

This PR updates the package name to be the correct value.

## Verification
<!-- Imagine your reviewer asking you these questions and then answer them here:
How were the changes validated? 
Were any automated tests added, updated, removed, or re-baselined? -->

After recompiling and re-uploading the jar file, I was able to schedule with aerie lander.

## Documentation
<!-- Imagine your reviewer asking you these questions and then answer them here.  
What documentation was invalidated by these changes?
What documentation should be added?
Which artifacts should reviewers check for accuracy and completeness? -->

None, this is a bug fix

## Future work
<!-- What next steps can we anticipate from here, if any? -->
None